### PR TITLE
Cache instances of `OnigScanner` to reduce memory usage

### DIFF
--- a/lib/onig.js
+++ b/lib/onig.js
@@ -4,11 +4,28 @@ const oniguruma = require("vscode-oniguruma");
 const onigPath = path.dirname(require.resolve("vscode-oniguruma"));
 const onigWASM = path.join(onigPath, 'onig.wasm');
 
+let PATTERN_CACHE = new Map();
+
+function keyForRegexps (regexps) {
+  return JSON.stringify(regexps)
+}
+
+function getCachedScannerForRegexps (regexps) {
+  return PATTERN_CACHE.get(keyForRegexps(regexps))
+}
+
+function setCachedScannerForRegexps (regexps, scanner) {
+  PATTERN_CACHE.set(keyForRegexps(regexps), scanner)
+}
+
 function patchOniguruma() {
-  const originalConstructor = oniguruma.OnigScanner;
+  const originalConstructor = oniguruma.OnigScanner
   oniguruma.OnigScanner = function (regexps) {
+    let scanner = getCachedScannerForRegexps(regexps)
+    if (scanner) { return scanner }
     const onigObject = new originalConstructor(regexps)
-    onigObject.source = regexps[0];
+    onigObject.source = regexps[0]
+    setCachedScannerForRegexps(regexps, onigObject)
     return onigObject
   }
 

--- a/spec/onig-scanner-spec.js
+++ b/spec/onig-scanner-spec.js
@@ -1,0 +1,24 @@
+const onig = require('../lib/onig')
+const chai = require('chai')
+const { expect } = chai
+
+describe("OnigScanner", () => {
+  let registry = null
+
+  beforeEach(async () => await onig.ready)
+
+  it("caches patterns so that equivalent pattern(s) return the same instance", () => {
+    let firstScanner = new onig.oniguruma.OnigScanner([/lorem/])
+    for (let i = 0; i < 10; i++) {
+      let scanner = new onig.oniguruma.OnigScanner([/lorem/])
+      expect(scanner === firstScanner).to.be.eql(true)
+    }
+
+    let anotherScanner = new onig.oniguruma.OnigScanner([/ipsum/, /dolor/, /lorem/])
+    for (let i = 0; i < 10; i++) {
+      let scanner = new onig.oniguruma.OnigScanner([/ipsum/, /dolor/, /lorem/])
+      expect(scanner === anotherScanner).to.be.eql(true)
+    }
+  })
+
+})

--- a/spec/onig-scanner-spec.js
+++ b/spec/onig-scanner-spec.js
@@ -8,15 +8,15 @@ describe("OnigScanner", () => {
   beforeEach(async () => await onig.ready)
 
   it("caches patterns so that equivalent pattern(s) return the same instance", () => {
-    let firstScanner = new onig.oniguruma.OnigScanner([/lorem/])
+    let firstScanner = new onig.oniguruma.OnigScanner(["lorem"])
     for (let i = 0; i < 10; i++) {
-      let scanner = new onig.oniguruma.OnigScanner([/lorem/])
+      let scanner = new onig.oniguruma.OnigScanner(["lorem"])
       expect(scanner === firstScanner).to.be.eql(true)
     }
 
-    let anotherScanner = new onig.oniguruma.OnigScanner([/ipsum/, /dolor/, /lorem/])
+    let anotherScanner = new onig.oniguruma.OnigScanner(["ipsum", "dolor", "lorem"])
     for (let i = 0; i < 10; i++) {
-      let scanner = new onig.oniguruma.OnigScanner([/ipsum/, /dolor/, /lorem/])
+      let scanner = new onig.oniguruma.OnigScanner(["ipsum", "dolor", "lorem"])
       expect(scanner === anotherScanner).to.be.eql(true)
     }
   })


### PR DESCRIPTION
I've written the only test I can think of to test.